### PR TITLE
prometheus metrics backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
-Vamp Node.js Client
--------------------
+# Vamp Node.js Client
 
+This is the NodeJS implementation for Vamp client.
+
+You can use specific metric backends using the following environment variable:
+
+`VAMP_METRICS_BACKEND=elasticsearch`
+
+Install using `node install`.
+
+## Examples using Elasticsearch
 ```javascript
 var _ = require('highland');
 var vamp = require('vamp-node-client');
@@ -12,7 +20,7 @@ var api = new vamp.Api({
 var metrics = new vamp.Metrics(api);
 ```
 
-Info
+### Info
 
 ```javascript
 api.info().each(function (info) {
@@ -20,7 +28,7 @@ api.info().each(function (info) {
 });
 ```
 
-Configuration
+### Configuration
 
 ```javascript
 api.config().each(function (config) {
@@ -28,13 +36,13 @@ api.config().each(function (config) {
 });
 ```
 
-Publishing an event
+### Publishing an event
 
 ```javascript
 api.event(['tag1:a', 'tag2:b'], 'abcd');
 ```
 
-Aggregate
+### Aggregate
 
 ```javascript
 metrics.average({ ft: 'abc' }, 'Tt', 30).each(function(response) {

--- a/backends/elasticsearch.js
+++ b/backends/elasticsearch.js
@@ -3,7 +3,14 @@
 var _ = require('highland');
 var elasticsearch = require('elasticsearch');
 
-module.exports = function($this, term, onrange, seconds) {
+module.exports = function($this, query_options) {
+    // Help:
+    // var query_options = {term: {ft:gateway.lookup_name}, on: 'Tt', seconds: 300};
+    var term = query_options.term;
+    var seconds = query_options.seconds;
+    var on = query_options.on || '';
+    var range = query_options.range || '';
+
     return {
         count: function (config) {
           var elasticsearchendpoint = process.env.VAMP_METRICS_ENDPOINT || config['vamp.pulse.elasticsearch.url'];
@@ -12,7 +19,7 @@ module.exports = function($this, term, onrange, seconds) {
             host: elasticsearchendpoint,
             log: 'error'
           });
-          $this.api.log('ELASTICSEARCH COUNT ' + JSON.stringify({term: term, range: onrange, seconds: seconds}));
+          $this.api.log('ELASTICSEARCH COUNT ' + JSON.stringify({term: term, range: range, seconds: seconds}));
           return _(esClient.search({
             index: config['vamp.gateway-driver.elasticsearch.metrics.index'],
             type: config['vamp.gateway-driver.elasticsearch.metrics.type'],
@@ -55,7 +62,7 @@ module.exports = function($this, term, onrange, seconds) {
           host: elasticsearchendpoint,
           log: 'error'
         });
-        $this.api.log('ELASTICSEARCH AVERAGE ' + JSON.stringify({term: term, on: onrange, seconds: seconds}));
+        $this.api.log('ELASTICSEARCH AVERAGE ' + JSON.stringify({term: term, on: on, seconds: seconds}));
         return _(esClient.search({
           index: config['vamp.gateway-driver.elasticsearch.metrics.index'],
           type: config['vamp.gateway-driver.elasticsearch.metrics.type'],
@@ -86,7 +93,7 @@ module.exports = function($this, term, onrange, seconds) {
             aggregations: {
               agg: {
                 avg: {
-                  field: onrange
+                  field: on
                 }
               }
             },

--- a/backends/elasticsearch.js
+++ b/backends/elasticsearch.js
@@ -1,0 +1,102 @@
+'use strict';
+
+var _ = require('highland');
+var elasticsearch = require('elasticsearch');
+
+module.exports = function($this, term, onrange, seconds) {
+    return {
+        count: function (config) {
+          var esClient = new elasticsearch.Client({
+            host: config['vamp.pulse.elasticsearch.url'],
+            log: 'error'
+          });
+          $this.api.log('ELASTICSEARCH COUNT ' + JSON.stringify({term: term, range: onrange, seconds: seconds}));
+          return _(esClient.search({
+            index: config['vamp.gateway-driver.elasticsearch.metrics.index'],
+            type: config['vamp.gateway-driver.elasticsearch.metrics.type'],
+            body: {
+              query: {
+                filtered: {
+                  query: {
+                    match_all: {}
+                  },
+                  filter: {
+                    bool: {
+                      must: [
+                        {
+                          term: term
+                        },
+                        {
+                          range: range
+                        },
+                        {
+                          range: {
+                            "@timestamp": {
+                              gt: "now-" + seconds + "s"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              size: 0
+            }
+          })).map(function (response) {
+            return response.hits.total;
+          });
+      },
+      average: function (config) {
+        var esClient = new elasticsearch.Client({
+          host: config['vamp.pulse.elasticsearch.url'],
+          log: 'error'
+        });
+        $this.api.log('ELASTICSEARCH AVERAGE ' + JSON.stringify({term: term, on: onrange, seconds: seconds}));
+        return _(esClient.search({
+          index: config['vamp.gateway-driver.elasticsearch.metrics.index'],
+          type: config['vamp.gateway-driver.elasticsearch.metrics.type'],
+          body: {
+            query: {
+              filtered: {
+                query: {
+                  match_all: {}
+                },
+                filter: {
+                  bool: {
+                    must: [
+                      {
+                        term: term
+                      },
+                      {
+                        range: {
+                          "@timestamp": {
+                            gt: "now-" + seconds + "s"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            aggregations: {
+              agg: {
+                avg: {
+                  field: onrange
+                }
+              }
+            },
+            size: 0
+          }
+        })).map(function (response) {
+          var total = response.hits.total;
+          return {
+            total: total,
+            rate: Math.round(total / seconds * 100) / 100,
+            average: Math.round(response.aggregations.agg.value * 100) / 100
+          };
+        });
+      }
+    };
+}

--- a/backends/elasticsearch.js
+++ b/backends/elasticsearch.js
@@ -6,8 +6,10 @@ var elasticsearch = require('elasticsearch');
 module.exports = function($this, term, onrange, seconds) {
     return {
         count: function (config) {
+          var elasticsearchendpoint = process.env.VAMP_METRICS_ENDPOINT || config['vamp.pulse.elasticsearch.url'];
+          // TODO: error when unable to connect with ES
           var esClient = new elasticsearch.Client({
-            host: config['vamp.pulse.elasticsearch.url'],
+            host: elasticsearchendpoint,
             log: 'error'
           });
           $this.api.log('ELASTICSEARCH COUNT ' + JSON.stringify({term: term, range: onrange, seconds: seconds}));
@@ -48,8 +50,9 @@ module.exports = function($this, term, onrange, seconds) {
           });
       },
       average: function (config) {
+        var elasticsearchendpoint = process.env.VAMP_METRICS_ENDPOINT || config['vamp.pulse.elasticsearch.url'];
         var esClient = new elasticsearch.Client({
-          host: config['vamp.pulse.elasticsearch.url'],
+          host: elasticsearchendpoint,
           log: 'error'
         });
         $this.api.log('ELASTICSEARCH AVERAGE ' + JSON.stringify({term: term, on: onrange, seconds: seconds}));

--- a/backends/elasticsearch.js
+++ b/backends/elasticsearch.js
@@ -11,9 +11,10 @@ module.exports = function($this, query_options) {
     var on = query_options.on || '';
     var range = query_options.range || '';
 
+    var elasticsearchendpoint = process.env.VAMP_METRICS_ENDPOINT || config['vamp.pulse.elasticsearch.url'];
+
     return {
         count: function (config) {
-          var elasticsearchendpoint = process.env.VAMP_METRICS_ENDPOINT || config['vamp.pulse.elasticsearch.url'];
           // TODO: error when unable to connect with ES
           var esClient = new elasticsearch.Client({
             host: elasticsearchendpoint,
@@ -57,7 +58,6 @@ module.exports = function($this, query_options) {
           });
       },
       average: function (config) {
-        var elasticsearchendpoint = process.env.VAMP_METRICS_ENDPOINT || config['vamp.pulse.elasticsearch.url'];
         var esClient = new elasticsearch.Client({
           host: elasticsearchendpoint,
           log: 'error'

--- a/backends/prometheus.js
+++ b/backends/prometheus.js
@@ -9,7 +9,11 @@ var rp = require('request-promise');
 
 var prom_endpoint = process.env.VAMP_METRICS_ENDPOINT || config['vamp.metrics.endpoint'];
 
-module.exports = function($this, frontend, code, none) {
+module.exports = function($this, query_options) {
+    // Help:
+    // var query_options = {frontend: gateway.lookup_name};
+    var frontend = query_options.frontend;
+
     var options = {
         uri: prom_endpoint + '/api/v1/query',
         headers: {
@@ -25,7 +29,6 @@ module.exports = function($this, frontend, code, none) {
         average: function(config) {
             var query = "sum(rate(haproxy_frontend_http_requests_total{frontend=\""+frontend+"\"}[10s])) by (frontend)";
             options.qs = {query: query};
-            _.log(query);
             return _(rp(options)
                 .then(function(v) {
                     var rps = Math.round(v.data.result[0].value[1] * 100) / 100;

--- a/backends/prometheus.js
+++ b/backends/prometheus.js
@@ -30,7 +30,7 @@ module.exports = function($this, query_options) {
             return _(rp(options)
                 .then(function(v) {
                     var total = Math.round(v.data.result[0].value[1]);
-                    var healthy = total? 0 : 1;
+                    var healthy = total > 0 ? 0 : 1;
                     return {
                         total: total,
                         healthy: healthy

--- a/backends/prometheus.js
+++ b/backends/prometheus.js
@@ -1,0 +1,44 @@
+/*
+ * Based on a 5s scrape interval.
+ */
+
+'use strict';
+
+var _ = require('highland');
+var rp = require('request-promise');
+
+var prom_endpoint = process.env.VAMP_METRICS_ENDPOINT || config['vamp.metrics.endpoint'];
+
+module.exports = function($this, frontend, code, none) {
+    var options = {
+        uri: prom_endpoint + '/api/v1/query',
+        headers: {
+            'User-Agent': 'Request-Promise'
+        },
+        json: true
+    };
+
+    return {
+        count: function(config) {
+            // TODO
+        },
+        average: function(config) {
+            var query = "sum(rate(haproxy_frontend_http_requests_total{frontend=\""+frontend+"\"}[10s])) by (frontend)";
+            options.qs = {query: query};
+            _.log(query);
+            return _(rp(options)
+                .then(function(v) {
+                    var rps = Math.round(v.data.result[0].value[1] * 100) / 100;
+                    // TODO: total and average should be filled, somehow...
+                    return {
+                      total: 0,
+                      rate: rps,
+                      average: 0
+                    };
+                })
+                .catch(function (err) {
+                    console.log(err);
+                }));
+        }
+    };
+}

--- a/backends/prometheus.js
+++ b/backends/prometheus.js
@@ -11,8 +11,9 @@ var prom_endpoint = process.env.VAMP_METRICS_ENDPOINT || config['vamp.metrics.en
 
 module.exports = function($this, query_options) {
     // Help:
-    // var query_options = {frontend: gateway.lookup_name};
+    // var query_options = {frontend: gateway.lookup_name, code: '5xx'};
     var frontend = query_options.frontend;
+    var code = query_options.code;
 
     var options = {
         uri: prom_endpoint + '/api/v1/query',
@@ -24,7 +25,20 @@ module.exports = function($this, query_options) {
 
     return {
         count: function(config) {
-            // TODO
+            var query = "sum(rate(haproxy_frontend_http_responses_total{frontend=\""+frontend+"\",code=\""+code+"\"}[10s])) by (frontend)";
+            options.qs = {query: query};
+            return _(rp(options)
+                .then(function(v) {
+                    var total = Math.round(v.data.result[0].value[1]);
+                    var healthy = total? 0 : 1;
+                    return {
+                        total: total,
+                        healthy: healthy
+                    };
+                })
+                .catch(function (err) {
+                    console.log(err);
+                }));
         },
         average: function(config) {
             var query = "sum(rate(haproxy_frontend_http_requests_total{frontend=\""+frontend+"\"}[10s])) by (frontend)";

--- a/metrics.js
+++ b/metrics.js
@@ -1,111 +1,22 @@
 'use strict';
 
+var metrics_backend_name = process.env.VAMP_METRICS_BACKEND || 'elasticsearch'
+
 var _ = require('highland');
-var elasticsearch = require('elasticsearch');
+var metrics_backend = require('./backends/' + metrics_backend_name);
 
 var Metrics = function (api) {
   this.api = api;
 };
 
-Metrics.prototype.count = function (term, range, seconds) {
+Metrics.prototype.count = function (term, onrange, seconds) {
   var $this = this;
-  return this.api.config().flatMap(function (config) {
-    var esClient = new elasticsearch.Client({
-      host: config['vamp.pulse.elasticsearch.url'],
-      log: 'error'
-    });
-    $this.api.log('ELASTICSEARCH COUNT ' + JSON.stringify({term: term, range: range, seconds: seconds}));
-    return _(esClient.search({
-      index: config['vamp.gateway-driver.elasticsearch.metrics.index'],
-      type: config['vamp.gateway-driver.elasticsearch.metrics.type'],
-      body: {
-        query: {
-          filtered: {
-            query: {
-              match_all: {}
-            },
-            filter: {
-              bool: {
-                must: [
-                  {
-                    term: term
-                  },
-                  {
-                    range: range
-                  },
-                  {
-                    range: {
-                      "@timestamp": {
-                        gt: "now-" + seconds + "s"
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          }
-        },
-        size: 0
-      }
-    })).map(function (response) {
-      return response.hits.total;
-    });
-  });
+  return this.api.config().flatMap(metrics_backend($this, term, onrange, seconds).count);
 };
 
-Metrics.prototype.average = function (term, on, seconds) {
+Metrics.prototype.average = function (term, onrange, seconds) {
   var $this = this;
-  return this.api.config().flatMap(function (config) {
-    var esClient = new elasticsearch.Client({
-      host: config['vamp.pulse.elasticsearch.url'],
-      log: 'error'
-    });
-    $this.api.log('ELASTICSEARCH AVERAGE ' + JSON.stringify({term: term, on: on, seconds: seconds}));
-    return _(esClient.search({
-      index: config['vamp.gateway-driver.elasticsearch.metrics.index'],
-      type: config['vamp.gateway-driver.elasticsearch.metrics.type'],
-      body: {
-        query: {
-          filtered: {
-            query: {
-              match_all: {}
-            },
-            filter: {
-              bool: {
-                must: [
-                  {
-                    term: term
-                  },
-                  {
-                    range: {
-                      "@timestamp": {
-                        gt: "now-" + seconds + "s"
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          }
-        },
-        aggregations: {
-          agg: {
-            avg: {
-              field: on
-            }
-          }
-        },
-        size: 0
-      }
-    })).map(function (response) {
-      var total = response.hits.total;
-      return {
-        total: total,
-        rate: Math.round(total / seconds * 100) / 100,
-        average: Math.round(response.aggregations.agg.value * 100) / 100
-      };
-    });
-  });
+  return this.api.config().flatMap(metrics_backend($this, term, onrange, seconds).average);
 };
 
 module.exports = Metrics;

--- a/metrics.js
+++ b/metrics.js
@@ -5,6 +5,8 @@ var metrics_backend_name = process.env.VAMP_METRICS_BACKEND || 'elasticsearch'
 var _ = require('highland');
 var metrics_backend = require('./backends/' + metrics_backend_name);
 
+_.log('Using metrics implementation ' + metrics_backend_name)
+
 var Metrics = function (api) {
   this.api = api;
 };

--- a/metrics.js
+++ b/metrics.js
@@ -11,14 +11,14 @@ var Metrics = function (api) {
   this.api = api;
 };
 
-Metrics.prototype.count = function (term, onrange, seconds) {
+Metrics.prototype.count = function (query_options) {
   var $this = this;
-  return this.api.config().flatMap(metrics_backend($this, term, onrange, seconds).count);
+  return this.api.config().flatMap(metrics_backend($this, query_options).count);
 };
 
-Metrics.prototype.average = function (term, onrange, seconds) {
+Metrics.prototype.average = function (query_options) {
   var $this = this;
-  return this.api.config().flatMap(metrics_backend($this, term, onrange, seconds).average);
+  return this.api.config().flatMap(metrics_backend($this, query_options).average);
 };
 
 module.exports = Metrics;


### PR DESCRIPTION
@olafmol @dragoslav your thoughts please!

Using this in breeds like `metrics.js` and `health.js` will however require some adjustments, so I'd say we'll probably want an abstraction or something in that area. Where the _vamp-node-client_ will just ask for health and the backend will decide the appropriate action (eg. querystring) to use.