### PR TITLE
Add support for Kubernetes using kubernetes-client

### DIFF
--- a/elasticsearch_metrics.js
+++ b/elasticsearch_metrics.js
@@ -60,7 +60,7 @@ module.exports = function (api) {
       return api.config().flatMap(function (config) {
         logger.log('ELASTICSEARCH AVERAGE ' + JSON.stringify({term: term, on: on, seconds: seconds}));
 
-        let url = config['vamp.pulse.elasticsearch.url'];
+        let url = process.env.ELASTICSEARCH_URL || config['vamp.pulse.elasticsearch.url'];
         let query = $this.query(config, term, seconds);
         query.body.aggregations = {
           agg: {

--- a/index.js
+++ b/index.js
@@ -4,4 +4,5 @@ exports.Log = require('./log');
 exports.Api = require('./api');
 exports.Util = require('./util');
 exports.Http = require('./http');
+exports.Kubernetes = require('./kubernetes');
 exports.ElasticsearchMetrics = require('./elasticsearch_metrics');

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -1,0 +1,26 @@
+'use strict';
+const Kubernetes = require('kubernetes-client');
+
+module.exports = function (opts) {
+    opts = opts || {};
+    opts.url = opts.url || process.env.KUBERNETES_URL;
+    opts.namespace = opts.namespace || process.env.KUBERNETES_NAMESPACE;
+
+    let config = {
+        url: opts.url,
+        namespace: opts.namespace
+    };
+
+    // If running within a Pod use Kubernetes' config
+    const host = process.env.KUBERNETES_SERVICE_HOST;
+    const port = process.env.KUBERNETES_SERVICE_PORT;
+    if (host && port) {
+        config = Api.config.getInCluster();
+    }
+
+    return {
+        api: () => new Kubernetes.Api(config),
+        core: () => new Kubernetes.Core(config),
+        extensions: () => new Kubernetes.Extensions(config)
+    }
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/magneticio/vamp-node-client#readme",
   "dependencies": {
-    "highland": "^3.0.0-beta.3"
+    "highland": "^3.0.0-beta.3",
+    "kubernetes-client": "^3.11.0"
   }
 }


### PR DESCRIPTION
My goals is to create a workflow which will create an `Ingress` resource in Kubernetes when an external gateway is triggered. This will automate the exposure of the team's services using the Kubernetes ingress functionality. Currently only Vamp itself is able to talk to Kubernetes but it's not possible to do this from a Workflow.

There is a nice Kubernetes client available which allow you to do this using JavaScript [kubernetes-client](https://github.com/godaddy/kubernetes-client). It supports talking to Kubernetes using customer configuration (Vamp Config, but also connecting from a Pod)